### PR TITLE
TASK: Reserve messages by updating with limit

### DIFF
--- a/Classes/Queue/DoctrineQueue.php
+++ b/Classes/Queue/DoctrineQueue.php
@@ -200,7 +200,9 @@ class DoctrineQueue implements QueueInterface
                 if ($numberOfUpdatedRows === 1) {
                     $lastUpdatedRow = $this->entityManager->getConnection()->lastInsertId();
                     $row = $this->connection->fetchAssoc("SELECT * FROM {$this->connection->quoteIdentifier($this->tableName)} WHERE id={$lastUpdatedRow}");
-                    return $this->getMessageFromRow($row);
+                    if(!$row) {
+                        return $this->getMessageFromRow($row);
+                    }
                 }
             } catch (TableNotFoundException $exception) {
                 throw new \RuntimeException(sprintf('The queue table "%s" could not be found. Did you run ./flow queue:setup "%s"?',

--- a/Classes/Queue/DoctrineQueue.php
+++ b/Classes/Queue/DoctrineQueue.php
@@ -200,7 +200,7 @@ class DoctrineQueue implements QueueInterface
                 if ($numberOfUpdatedRows === 1) {
                     $lastUpdatedRow = $this->entityManager->getConnection()->lastInsertId();
                     $row = $this->connection->fetchAssoc("SELECT * FROM {$this->connection->quoteIdentifier($this->tableName)} WHERE id={$lastUpdatedRow}");
-                    if(!$row) {
+                    if($row !== false) {
                         return $this->getMessageFromRow($row);
                     }
                 }


### PR DESCRIPTION
This uses an update statement with limit 1 to reserve messages.
The actual message is selected afterwards by reading the LAST_INSERT_ID that
is filled in the update statement.
This reduces the risk of deadlocks in high load environments.

I'm not sure if this would work on Postgres as well but we did load tests and noticed that by reserving messages that way every message still gets processed only once but the risk of deadlocks is reserved.
Also the select to read the row is only needed if a message in the database has actually been updated.

We're still testing this but it seems to be working quite well and we've noticed no issues so far.