### PR TITLE
[TASK] Remove beanstalkd configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,6 @@ Flowpack:
           className: 'Flowpack\JobQueue\Doctrine\Queue\DoctrineQueue'
           executeIsolated: true
           options:
-            client:
-              host: 127.0.0.11
-              port: 11301
             defaultTimeout: 50
           releaseOptions:
             priority: 512


### PR DESCRIPTION
In the example a number of beanstalkd configuraiton options are present. They have no effect and is not mentioned anywhere else

Resolves #14