### PR TITLE
BUGFIX: Make it safe to run setup more than once

### DIFF
--- a/Classes/Queue/DoctrineQueue.php
+++ b/Classes/Queue/DoctrineQueue.php
@@ -114,7 +114,11 @@ class DoctrineQueue implements QueueInterface
                 $createDatabaseStatement = "CREATE TABLE IF NOT EXISTS {$this->connection->quoteIdentifier($this->tableName)} (id INTEGER PRIMARY KEY AUTO_INCREMENT, payload LONGTEXT NOT NULL, state VARCHAR(255) NOT NULL, failures INTEGER NOT NULL DEFAULT 0, scheduled DATETIME DEFAULT NULL) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB";
         }
         $this->connection->exec($createDatabaseStatement);
-        $this->connection->exec("CREATE INDEX state_scheduled ON {$this->connection->quoteIdentifier($this->tableName)} (state, scheduled)");
+        try {
+            $this->connection->exec("CREATE INDEX state_scheduled ON {$this->connection->quoteIdentifier($this->tableName)} (state, scheduled)");
+        } catch (Exception $e) {
+            // See https://dba.stackexchange.com/questions/24531/mysql-create-index-if-not-exists
+        }
     }
 
     /**


### PR DESCRIPTION
There is no `CREATE INDEX IF NOT EXISTS` in MySql, so we need to try/catch to make the operation optional.
See https://dba.stackexchange.com/questions/24531/mysql-create-index-if-not-exists
Fixes #12