### PR TITLE
BUGFIX: Use fullyqualified classname for exception

### DIFF
--- a/Classes/Queue/DoctrineQueue.php
+++ b/Classes/Queue/DoctrineQueue.php
@@ -116,7 +116,7 @@ class DoctrineQueue implements QueueInterface
         $this->connection->exec($createDatabaseStatement);
         try {
             $this->connection->exec("CREATE INDEX state_scheduled ON {$this->connection->quoteIdentifier($this->tableName)} (state, scheduled)");
-        } catch (Exception $e) {
+        } catch (\Doctrine\DBAL\Exception $e) {
             // See https://dba.stackexchange.com/questions/24531/mysql-create-index-if-not-exists
         }
     }

--- a/Classes/Queue/DoctrineQueue.php
+++ b/Classes/Queue/DoctrineQueue.php
@@ -19,7 +19,6 @@ use Doctrine\DBAL\Exception\InvalidArgumentException;
 use Doctrine\DBAL\Exception\TableNotFoundException;
 use Flowpack\JobQueue\Common\Queue\Message;
 use Flowpack\JobQueue\Common\Queue\QueueInterface;
-use Neos\Flow\Annotations as Flow;
 
 /**
  * A queue implementation using doctrine as the queue backend
@@ -116,7 +115,7 @@ class DoctrineQueue implements QueueInterface
         $this->connection->exec($createDatabaseStatement);
         try {
             $this->connection->exec("CREATE INDEX state_scheduled ON {$this->connection->quoteIdentifier($this->tableName)} (state, scheduled)");
-        } catch (\Doctrine\DBAL\Exception $e) {
+        } catch (DBALException $e) {
             // See https://dba.stackexchange.com/questions/24531/mysql-create-index-if-not-exists
         }
     }


### PR DESCRIPTION
This PR changes the exception class to be caught, to be the root Exception class of doctrine/dbal

With this change we can run the setup, with no errors shown (see related issue)

**Before**

```
> /flow queue:setup default
Queue "default" has been initialized successfully.
> ./flow queue:setup default
An error occurred while trying to setup queue "default":
An exception occurred while executing 'CREATE INDEX state_scheduled ON `flowpack_jobqueue_messages_default` (state, scheduled)':

SQLSTATE[42000]: Syntax error or access violation: 1061 Duplicate key name 'state_scheduled' (#0)
```

**After**

```
> ./flow queue:setup default
Queue "default" has been initialized successfully.
> ./flow queue:setup default
Queue "default" has been initialized successfully.
```

Fixes: #18 