### PR TITLE
BUGFIX: "Error 2006 - Server gone away" after processing a job longer than the database timeout

### DIFF
--- a/Tests/Functional/Queue/DoctrineQueueTest.php
+++ b/Tests/Functional/Queue/DoctrineQueueTest.php
@@ -25,6 +25,6 @@ class DoctrineQueueTest extends AbstractQueueTest
      */
     protected function getQueue()
     {
-        return new DoctrineQueue('Test-queue', $this->queueSettings);
+        return new DoctrineQueue('testqueue', $this->queueSettings);
     }
 }


### PR DESCRIPTION
If a job is executed by the queue, which lasts longer than the timeout of the database server, a deletion of the message from the queue is no longer possible. In this case Doctrine throws a `DBALException`.

With this bugfix, when the relevant methods of the `DoctrineQueue` are called, it is first checked whether a database connection still exists and, in the event of an exception, an attempt is made to establish a new database connection.