### PR TITLE
FEATURE: Introduce boost mode

### DIFF
--- a/Classes/Queue/DoctrineQueue.php
+++ b/Classes/Queue/DoctrineQueue.php
@@ -92,16 +92,16 @@ class DoctrineQueue implements QueueInterface
     {
         $this->name = $name;
         if (isset($options['defaultTimeout'])) {
-            $this->defaultTimeout = (integer)$options['defaultTimeout'];
+            $this->defaultTimeout = (int)$options['defaultTimeout'];
         }
         if (isset($options['pollInterval'])) {
-            $this->pollInterval = (integer)($options['pollInterval'] * 1000000);
+            $this->pollInterval = (int)($options['pollInterval'] * 1000000);
         }
         if (isset($options['boostPollInterval'])) {
-            $this->boostPollInterval = (integer)($options['boostPollInterval'] * 1000000);
+            $this->boostPollInterval = (int)($options['boostPollInterval'] * 1000000);
         }
         if (isset($options['boostTime'])) {
-            $this->boostTime = (integer)($options['boostTime'] * 1000000);
+            $this->boostTime = (int)($options['boostTime'] * 1000000);
         }
         if (isset($options['tableName'])) {
             $this->tableName = $options['tableName'];
@@ -187,7 +187,7 @@ class DoctrineQueue implements QueueInterface
             return null;
         }
 
-        $numberOfDeletedRows = $this->connection->delete($this->connection->quoteIdentifier($this->tableName), ['id' => (integer)$message->getIdentifier()]);
+        $numberOfDeletedRows = $this->connection->delete($this->connection->quoteIdentifier($this->tableName), ['id' => (int)$message->getIdentifier()]);
         if ($numberOfDeletedRows !== 1) {
             // TODO error handling
             return null;
@@ -225,7 +225,7 @@ class DoctrineQueue implements QueueInterface
                 throw new \RuntimeException(sprintf('The queue table "%s" could not be found. Did you run ./flow queue:setup "%s"?', $this->tableName, $this->name), 1469117906, $exception);
             }
             if ($row !== false) {
-                $numberOfUpdatedRows = (int)$this->connection->executeStatement("UPDATE {$this->connection->quoteIdentifier($this->tableName)} SET state = 'reserved' WHERE id = :id AND state = 'ready' AND {$this->getScheduledQueryConstraint()}", ['id' => (integer)$row['id']]);
+                $numberOfUpdatedRows = (int)$this->connection->executeStatement("UPDATE {$this->connection->quoteIdentifier($this->tableName)} SET state = 'reserved' WHERE id = :id AND state = 'ready' AND {$this->getScheduledQueryConstraint()}", ['id' => (int)$row['id']]);
                 if ($numberOfUpdatedRows === 1) {
                     $this->lastMessageTime = time();
                     return $this->getMessageFromRow($row);
@@ -246,7 +246,7 @@ class DoctrineQueue implements QueueInterface
      */
     public function release(string $messageId, array $options = []): void
     {
-        $this->connection->executeStatement("UPDATE {$this->connection->quoteIdentifier($this->tableName)} SET state = 'ready', failures = failures + 1, scheduled = {$this->resolveScheduledQueryPart($options)} WHERE id = :id", ['id' => (integer)$messageId]);
+        $this->connection->executeStatement("UPDATE {$this->connection->quoteIdentifier($this->tableName)} SET state = 'ready', failures = failures + 1, scheduled = {$this->resolveScheduledQueryPart($options)} WHERE id = :id", ['id' => (int)$messageId]);
     }
 
     /**
@@ -254,7 +254,7 @@ class DoctrineQueue implements QueueInterface
      */
     public function abort(string $messageId): void
     {
-        $this->connection->update($this->connection->quoteIdentifier($this->tableName), ['state' => 'failed'], ['id' => (integer)$messageId]);
+        $this->connection->update($this->connection->quoteIdentifier($this->tableName), ['state' => 'failed'], ['id' => (int)$messageId]);
     }
 
     /**
@@ -263,7 +263,7 @@ class DoctrineQueue implements QueueInterface
      */
     public function finish(string $messageId): bool
     {
-        return $this->connection->delete($this->connection->quoteIdentifier($this->tableName), ['id' => (integer)$messageId]) === 1;
+        return $this->connection->delete($this->connection->quoteIdentifier($this->tableName), ['id' => (int)$messageId]) === 1;
     }
 
     /**
@@ -286,7 +286,7 @@ class DoctrineQueue implements QueueInterface
      */
     public function countReady(): int
     {
-        return (integer)$this->connection->fetchOne("SELECT COUNT(*) FROM {$this->connection->quoteIdentifier($this->tableName)} WHERE state = 'ready'");
+        return (int)$this->connection->fetchOne("SELECT COUNT(*) FROM {$this->connection->quoteIdentifier($this->tableName)} WHERE state = 'ready'");
     }
 
     /**
@@ -294,7 +294,7 @@ class DoctrineQueue implements QueueInterface
      */
     public function countReserved(): int
     {
-        return (integer)$this->connection->fetchOne("SELECT COUNT(*) FROM {$this->connection->quoteIdentifier($this->tableName)} WHERE state = 'reserved'");
+        return (int)$this->connection->fetchOne("SELECT COUNT(*) FROM {$this->connection->quoteIdentifier($this->tableName)} WHERE state = 'reserved'");
     }
 
     /**
@@ -302,7 +302,7 @@ class DoctrineQueue implements QueueInterface
      */
     public function countFailed(): int
     {
-        return (integer)$this->connection->fetchColumn("SELECT COUNT(*) FROM {$this->connection->quoteIdentifier($this->tableName)} WHERE state = 'failed'");
+        return (int)$this->connection->fetchColumn("SELECT COUNT(*) FROM {$this->connection->quoteIdentifier($this->tableName)} WHERE state = 'failed'");
     }
 
     /**
@@ -321,7 +321,7 @@ class DoctrineQueue implements QueueInterface
      */
     protected function getMessageFromRow(array $row): Message
     {
-        return new Message($row['id'], json_decode($row['payload'], true), (integer)$row['failures']);
+        return new Message($row['id'], json_decode($row['payload'], true), (int)$row['failures']);
     }
 
     /**
@@ -335,11 +335,11 @@ class DoctrineQueue implements QueueInterface
         }
         switch ($this->connection->getDatabasePlatform()->getName()) {
             case 'sqlite':
-                return 'datetime(\'now\', \'+' . (integer)$options['delay'] . ' second\')';
+                return 'datetime(\'now\', \'+' . (int)$options['delay'] . ' second\')';
             case 'postgresql':
-                return 'NOW() + INTERVAL \'' . (integer)$options['delay'] . ' SECOND\'';
+                return 'NOW() + INTERVAL \'' . (int)$options['delay'] . ' SECOND\'';
             default:
-                return 'DATE_ADD(NOW(), INTERVAL ' . (integer)$options['delay'] . ' SECOND)';
+                return 'DATE_ADD(NOW(), INTERVAL ' . (int)$options['delay'] . ' SECOND)';
         }
     }
 
@@ -355,7 +355,7 @@ class DoctrineQueue implements QueueInterface
                 return '(scheduled IS NULL OR scheduled <= NOW())';
         }
     }
-    
+
     /**
      * Reconnects the database connection associated with this queue, if it doesn't respond to a ping
      *

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -17,6 +17,8 @@
 #
 #            defaultTimeout: 60
 #            pollInterval: 1
+#            boostPollInterval: 0.5
+#            boostTime: 10
 #
 #            If no "tableName" is specified, a table name prefixed with "flowpack_jobqueue_messages_" will be used:
 #            tableName: 'custom_table_name'

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # Flowpack.JobQueue.Doctrine
 
-A job queue backend for the [Flowpack.JobQueue.Common](https://github.com/Flowpack/jobqueue-common) package based on [Doctrine](http://www.doctrine-project.org/).
+A job queue backend for the [Flowpack.JobQueue.Common](https://github.
+com/Flowpack/jobqueue-common) package based on [Doctrine](http://www.doctrine-project.org/).
 
 ## Usage
 
-Install the package using composer:
+Install the package using Composer:
 
 ```
 composer require flowpack/jobqueue-doctrine
 ```
 
-If not already installed, that will fetch its requirements, namely the `jobqueue-common` package.
+If not already installed, that will fetch its requirements, namely the 
+`jobqueue-common` package.
 
 Now the queue can be configured like this:
 
@@ -35,34 +37,53 @@ The required tables can be created executing:
 ./flow queue:setup some-queue
 ```
 
+## Boost Mode
+
+The poll interval should be short enough to process messages in time, and long
+enough to minimize resource consumption for the database. Boost mode is a 
+solution which automatically handles spikes by processing messages in quick 
+succession. When no new messages appear for a specified time, boost mode is
+disabled again.
+
+The frequency by which the queue loop will look for new messages is the 
+configured `pollInterval`. In boost mode, the option `boostPollInterval` is 
+used instead. `boostTime` defines the time since the last processed message 
+after which boost mode is deactivated again.
+
 ## Specific options
 
 The `DoctrineQueue` supports following options:
 
-| Option                  | Type    | Default                                 | Description                              |
-| ----------------------- |---------| ---------------------------------------:| ---------------------------------------- |
-| defaultTimeout          | integer | 60                                      | Number of seconds new messages are waited for before a timeout occurs (This is overridden by a "timeout" argument in the `waitAndTake()` and `waitAndReserve()` methods |
-| pollInterval            | integer | 1                                       | Number of seconds between SQL lookups for new messages |
-| tableName               | string  | flowpack_jobqueue_messages_<queue-name> | Name of the database table for this queue. By default this is the queue name prefixed with "flowpack_jobqueue_messages_" |
-| backendOptions          | array   | -                                       | Doctrine-specific connection params (see [Doctrine reference](http://doctrine-orm.readthedocs.io/projects/doctrine-dbal/en/latest/reference/configuration.html))|
+| Option            | Type    |                                 Default | Description                                                                                                                                                             |
+|-------------------|---------|----------------------------------------:|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| defaultTimeout    | integer |                                      60 | Number of seconds new messages are waited for before a timeout occurs, this is overridden by a "timeout" argument in the `waitAndTake()` and `waitAndReserve()` methods |
+| pollInterval      | float   |                                       1 | Number of seconds between SQL lookups for new messages                                                                                                                  |
+| boostPollInterval | float   |                                     0.5 | Number of seconds between SQL lookups for new messages when in "boost mode"                                                                                             |
+| boostTime         | float   |                                      10 | Maximum number of seconds since last processed message to activate "boost mode"                                                                                         |
+| tableName         | string  | flowpack_jobqueue_messages_<queue-name> | Name of the database table for this queue. By default this is the queue name prefixed with "flowpack_jobqueue_messages_"                                                |
+| backendOptions    | array   |                                       - | Doctrine-specific connection params (see [Doctrine reference](http://doctrine-orm.readthedocs.io/projects/doctrine-dbal/en/latest/reference/configuration.html))        |
 
-*NOTE:* The `DoctrineQueue` currently supports `MySQL`, `PostgreSQL` and `SQLite` backends. You can specify the backend via the `backendOptions`. If you omit this setting, the *current connection* will be re-used (i.e. the currently active Flow database).
+*NOTE:* The `DoctrineQueue` currently supports `MySQL`, `PostgreSQL` and 
+`SQLite` backends. You can specify the backend via the `backendOptions`. If 
+you omit this setting, the *current connection* will be re-used (i.e. the 
+currently active Flow database).
 
 ### Submit options
 
-Additional options supported by `JobManager::queue()`, `DoctrineQueue::submit()` and the `Job\Defer` annotation:
+Additional options supported by `JobManager::queue()`, `DoctrineQueue::submit
+()` and the `Job\Defer` annotation:
 
-| Option                  | Type    | Default          | Description                              |
-| ----------------------- |---------| ----------------:| ---------------------------------------- |
-| delay                   | integer | 0                | Number of seconds before a message is marked "ready" after submission. This can be useful to prevent premature execution of jobs (i.e. before entities are persisted) |
+| Option | Type    | Default | Description                                                                                                                                                           |
+|--------|---------|--------:|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| delay  | integer |       0 | Number of seconds before a message is marked "ready" after submission. This can be useful to prevent premature execution of jobs (i.e. before entities are persisted) |
 
 ### Release options
 
 Additional options to be specified via `releaseOptions`: 
 
-| Option                  | Type    | Default          | Description                              |
-| ----------------------- |---------| ----------------:| ---------------------------------------- |
-| delay                   | integer | 0                | Number of seconds before a message is marked "ready" after it has been released. |
+| Option | Type    | Default | Description                                                                      |
+|--------|---------|--------:|----------------------------------------------------------------------------------|
+| delay  | integer |       0 | Number of seconds before a message is marked "ready" after it has been released. |
 
 ## License
 


### PR DESCRIPTION
This change introduces new configuration options for a "boost mode".

The poll interval should be short enough to process messages in time, and long enough to minimize resource consumption for the database. Boost mode is a solution which automatically handles spikes by processing messages in quick succession. When no new messages appear for a specified time, boost mode is disabled again.

Through this change, `pollInterval` now also accepts fractions of seconds, for example "0.5" for half a second.